### PR TITLE
Fix for a unity related exception throw due to FindObjectsOfTypeAll

### DIFF
--- a/SpectrumTestPlugin/Entry.cs
+++ b/SpectrumTestPlugin/Entry.cs
@@ -1,9 +1,6 @@
 ﻿using Spectrum.API.Interfaces.Plugins;
 using Spectrum.API.Interfaces.Systems;
 using SpectrumTestPlugin.UI;
-using System;
-using System.Collections.Generic;
-using UnityEngine;
 
 namespace SpectrumTestPlugin
 {
@@ -15,31 +12,14 @@ namespace SpectrumTestPlugin
             {
                 if (data.sceneName == "MainMenu")
                 {
-                    CreateMenu(manager, "SpectrumSettingsObject", "OptionsFrontRoot", "MainMenuFrontRoot");
+                    Menu.Create<SpectrumSettingsMenu>(manager, "SpectrumSettingsObject", "OptionsFrontRoot", "MainMenuFrontRoot");
                 }
             });
 
             Events.Game.ModeInitialized.Subscribe((data) =>
             {
-                CreateMenu(manager, "SpectrumSettingsObject", "OptionsFrontRoot(Clone)", "PauseMenuRoot");
+                Menu.Create<SpectrumSettingsMenu>(manager, "SpectrumSettingsObject", "OptionsFrontRoot(Clone)", "PauseMenuRoot");
             });
-        }
-
-        private void CreateMenu(IManager manager, string settingsObjectName, string optionsFrontRootName, string mainMenuFrontRootName)
-        {
-            var spectrumSettingsObject = new GameObject(settingsObjectName);
-            var menuController = spectrumSettingsObject.AddComponent<SpectrumSettingsMenu>();
-            menuController.SetManager(manager);
-
-            var optionsLogic = Util.FindByName(optionsFrontRootName).GetComponent<OptionsMenuLogic>();
-            var options = new List<OptionsSubmenu>();
-            options.AddRange(optionsLogic.subMenus_);
-            options.Add(menuController);
-            optionsLogic.subMenus_ = options.ToArray();
-
-            var mainMenuLogic = Util.FindByName(mainMenuFrontRootName).GetComponent<MainMenuLogic>();
-            List<MenuButtonList.ButtonInfo> buttonInfos = mainMenuLogic.optionsButtons_.GetButtonInfos(optionsLogic, false);
-            mainMenuLogic.optionsButtons_.Init(buttonInfos);
         }
     }
 }

--- a/SpectrumTestPlugin/SpectrumTestPlugin.csproj
+++ b/SpectrumTestPlugin/SpectrumTestPlugin.csproj
@@ -31,10 +31,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>D:\Steam\steamapps\common\Distance\Distance_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\Steam\steamapps\common\Distance\Distance_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Spectrum.API">
-      <HintPath>D:\Steam\steamapps\common\Distance\Distance_Data\Spectrum\Spectrum.API.dll</HintPath>
+      <HintPath>..\..\..\Steam\steamapps\common\Distance\Distance_Data\Spectrum\Spectrum.API.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -43,12 +43,13 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>D:\Steam\steamapps\common\Distance\Distance_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\Steam\steamapps\common\Distance\Distance_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Entry.cs" />
     <Compile Include="SpectrumSettingsMenu.cs" />
+    <Compile Include="UI\Menu.cs" />
     <Compile Include="UI\OptionsSubmenu\MainOptionsSubmenuButton.cs" />
     <Compile Include="UI\OptionsSubmenu\OptionsSubmenuButton.cs" />
     <Compile Include="UI\OptionsSubmenu\PauseOptionsSubmenuButton.cs" />

--- a/SpectrumTestPlugin/UI/Menu.cs
+++ b/SpectrumTestPlugin/UI/Menu.cs
@@ -1,0 +1,48 @@
+﻿using Spectrum.API.Interfaces.Systems;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace SpectrumTestPlugin.UI
+{
+    static class Menu
+    {
+        public static GameObject menuBlueprint;
+
+        public static void Create<T>(IManager manager, string settingsObjectName, string optionsFrontRootName, string mainMenuFrontRootName) where T : SpectrumMenu
+        {
+            menuBlueprint = Util.FindByName("SuperMenuBlueprint");
+
+            var spectrumSettingsObject = new GameObject(settingsObjectName);
+            var menuController = spectrumSettingsObject.AddComponent<T>();
+            menuController.SetManager(manager);
+
+            var optionsLogic = Util.FindByName(optionsFrontRootName).GetComponent<OptionsMenuLogic>();
+            var options = new List<OptionsSubmenu>();
+            options.AddRange(optionsLogic.subMenus_);
+            options.Add(menuController);
+            optionsLogic.subMenus_ = options.ToArray();
+
+            var mainMenuLogic = Util.FindByName(mainMenuFrontRootName).GetComponent<MainMenuLogic>();
+            List<MenuButtonList.ButtonInfo> buttonInfos = mainMenuLogic.optionsButtons_.GetButtonInfos(optionsLogic, false);
+            mainMenuLogic.optionsButtons_.Init(buttonInfos);
+        }
+
+        public static void Create<T>(IManager manager, string settingsObjectName) where T : SpectrumMenu
+        {
+            Create<T>(manager, settingsObjectName, GetOptionsRoot(), GetMenuRoot());
+        }
+
+        private static string GetOptionsRoot()
+        {
+            string scene = SceneManager.GetActiveScene().name.ToLower();
+            return scene == "mainmenu" ? "OptionsFrontRoot" : "OptionsFrontRoot(Clone)";
+        }
+
+        private static string GetMenuRoot()
+        {
+            string scene = SceneManager.GetActiveScene().name.ToLower();
+            return scene == "mainmenu" ? "MainMenuFrontRoot" : "PauseMenuRoot";
+        }
+    }
+}

--- a/SpectrumTestPlugin/UI/SpectrumMenu.cs
+++ b/SpectrumTestPlugin/UI/SpectrumMenu.cs
@@ -13,7 +13,7 @@ namespace SpectrumTestPlugin.UI
 
         public SpectrumMenu()
         {
-            menuBlueprint_ = Util.FindByName("SuperMenuBlueprint");
+            menuBlueprint_ = Menu.menuBlueprint;
         }
         
         public void SetManager(IManager manager)


### PR DESCRIPTION
Moved Util.FindByName("SuperMenuBlueprint") outside of the SpectrumMenu class constructor due to Unity not allowing calls to Resources.FindObjectsOfTypeAll in a MonoBehaviour constructor.
Added a generic method to add a menu (Menu.Create<T>([...]).
Removed some unused using statements.